### PR TITLE
Override get_state_string to account for prechecks

### DIFF
--- a/behaviour.php
+++ b/behaviour.php
@@ -60,6 +60,15 @@ class qbehaviour_adaptive_adapted_for_coderunner extends qbehaviour_adaptive {
         return $vars;
     }
 
+    // Override parent method to allow for the added 'precheck' button.
+    public function get_state_string($showcorrectness) {
+        $laststep = $this->qa->get_last_step();
+        if ($laststep->has_behaviour_var('precheck')) {
+            return get_string('precheckresults', 'qbehaviour_adaptive_adapted_for_coderunner');
+        }
+
+        return parent::get_state_string($showcorrectness);
+    }
 
     // Override parent method to allow for the added 'precheck' button.
     public function process_action(question_attempt_pending_step $pendingstep) {

--- a/lang/en/qbehaviour_adaptive_adapted_for_coderunner.php
+++ b/lang/en/qbehaviour_adaptive_adapted_for_coderunner.php
@@ -27,5 +27,6 @@ $string['notcomplete'] = 'Not complete';
 $string['pluginname'] = 'Adaptive adapted for coderunner';
 $string['precheck'] = 'Precheck';
 $string['precheckedresponse'] = 'Prechecked: {$a}';
+$string['precheckresults'] = 'Precheck results';
 $string['triesremaining'] = 'Tries remaining: {$a}';
 $string['tryagain'] = 'Try again';


### PR DESCRIPTION
This is the fix for issue #6. Feel free to amend the text if you like.

Note there is a separate pull request for qtype_coderunner to add this to the unit test.