### PR TITLE
Fix implementation get_reason() in provider in correct

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -32,7 +32,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return  string
      */
-    public static function get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }


### PR DESCRIPTION
Hi @trampgeek 
This pull request to fix implementation provider::get_reason() must be compatible with core_privacy\local\metadata\null_provider::get_reason().
Please check and accept.

Thank you.